### PR TITLE
Render errors with Turbo streams

### DIFF
--- a/app/controllers/spina/admin/conferences/conferences_controller.rb
+++ b/app/controllers/spina/admin/conferences/conferences_controller.rb
@@ -58,7 +58,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @conference.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @conference.errors } }
             end
           end
         end
@@ -74,7 +74,7 @@ module Spina
                 add_breadcrumb @conference.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @conference.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @conference.errors } }
             end
           end
         end
@@ -90,7 +90,7 @@ module Spina
                 add_breadcrumb @conference.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @conference.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @conference.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/delegates_controller.rb
+++ b/app/controllers/spina/admin/conferences/delegates_controller.rb
@@ -44,7 +44,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @delegate.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @delegate.errors } }
             end
           end
         end
@@ -60,7 +60,7 @@ module Spina
                 add_breadcrumb @delegate.full_name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @delegate.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @delegate.errors } }
             end
           end
         end
@@ -76,7 +76,7 @@ module Spina
                 add_breadcrumb @delegate.full_name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @delegate.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @delegate.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/dietary_requirements_controller.rb
+++ b/app/controllers/spina/admin/conferences/dietary_requirements_controller.rb
@@ -44,7 +44,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @dietary_requirement.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @dietary_requirement.errors } }
             end
           end
         end
@@ -60,7 +60,7 @@ module Spina
                 add_breadcrumb @dietary_requirement.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @dietary_requirement.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @dietary_requirement.errors } }
             end
           end
         end
@@ -76,7 +76,7 @@ module Spina
                 add_breadcrumb @dietary_requirement.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @dietary_requirement.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @dietary_requirement.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/institutions_controller.rb
+++ b/app/controllers/spina/admin/conferences/institutions_controller.rb
@@ -44,7 +44,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @institution.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @institution.errors } }
             end
           end
         end
@@ -60,7 +60,7 @@ module Spina
                 add_breadcrumb @institution.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @institution.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @institution.errors } }
             end
           end
         end
@@ -76,7 +76,7 @@ module Spina
                 add_breadcrumb @institution.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @institution.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @institution.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/presentation_attachment_types_controller.rb
+++ b/app/controllers/spina/admin/conferences/presentation_attachment_types_controller.rb
@@ -43,7 +43,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation_attachment_type.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation_attachment_type.errors } }
             end
           end
         end
@@ -59,7 +59,7 @@ module Spina
                 add_breadcrumb @presentation_attachment_type.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation_attachment_type.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation_attachment_type.errors } }
             end
           end
         end
@@ -75,7 +75,7 @@ module Spina
                 add_breadcrumb @presentation_attachment_type.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation_attachment_type.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation_attachment_type.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/presentation_types_controller.rb
+++ b/app/controllers/spina/admin/conferences/presentation_types_controller.rb
@@ -46,7 +46,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation_type.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation_type.errors } }
             end
           end
         end
@@ -62,7 +62,7 @@ module Spina
                 add_breadcrumb @presentation_type.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation_type.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation_type.errors } }
             end
           end
         end
@@ -78,7 +78,7 @@ module Spina
                 add_breadcrumb @presentation_type.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation_type.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation_type.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/presentations_controller.rb
+++ b/app/controllers/spina/admin/conferences/presentations_controller.rb
@@ -45,7 +45,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation.errors } }
             end
           end
         end
@@ -61,7 +61,7 @@ module Spina
                 add_breadcrumb @presentation.title
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation.errors } }
             end
           end
         end
@@ -77,7 +77,7 @@ module Spina
                 add_breadcrumb @presentation.title
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @presentation.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @presentation.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/rooms_controller.rb
+++ b/app/controllers/spina/admin/conferences/rooms_controller.rb
@@ -46,7 +46,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @room.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @room.errors } }
             end
           end
         end
@@ -62,7 +62,7 @@ module Spina
                 add_breadcrumb @room.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @room.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @room.errors } }
             end
           end
         end
@@ -78,7 +78,7 @@ module Spina
                 add_breadcrumb @room.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @room.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @room.errors } }
             end
           end
         end

--- a/app/controllers/spina/admin/conferences/sessions_controller.rb
+++ b/app/controllers/spina/admin/conferences/sessions_controller.rb
@@ -47,7 +47,7 @@ module Spina
                 add_breadcrumb t('.new')
                 render :new
               end
-              format.js { render partial: 'errors', locals: { errors: @session.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @session.errors } }
             end
           end
         end
@@ -63,7 +63,7 @@ module Spina
                 add_breadcrumb @session.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @session.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @session.errors } }
             end
           end
         end
@@ -79,7 +79,7 @@ module Spina
                 add_breadcrumb @session.name
                 render :edit
               end
-              format.js { render partial: 'errors', locals: { errors: @session.errors } }
+              format.turbo_stream { render partial: 'errors', locals: { errors: @session.errors } }
             end
           end
         end

--- a/app/views/spina/admin/conferences/application/_errors.js.erb
+++ b/app/views/spina/admin/conferences/application/_errors.js.erb
@@ -1,2 +1,0 @@
-document.querySelector('aside#notifications')
-  .insertAdjacentHTML('beforeend', '<%= j(render partial: 'errors', formats: :html, locals: { errors: errors }) %>');

--- a/app/views/spina/admin/conferences/application/_errors.turbo_stream.haml
+++ b/app/views/spina/admin/conferences/application/_errors.turbo_stream.haml
@@ -1,0 +1,1 @@
+= turbo_stream.append('notifications') { render partial: 'errors', formats: :html, locals: { errors: errors } }

--- a/app/views/spina/admin/conferences/conferences/_form.html.haml
+++ b/app/views/spina/admin/conferences/conferences/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @conference.errors
 
-= form_for @conference, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @conference, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/conferences/_form_conference_details.html.haml
+++ b/app/views/spina/admin/conferences/conferences/_form_conference_details.html.haml
@@ -26,4 +26,4 @@
                 = render 'event_fields', f: event_fields
 
   - unless @conference.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_conference_path(@conference), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', name: @conference.name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_conference_path(@conference), method: :delete, data: { confirm: t('.delete_confirmation', name: @conference.name) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/delegates/_form.html.haml
+++ b/app/views/spina/admin/conferences/delegates/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @delegate.errors
 
-= form_for @delegate, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @delegate, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/delegates/_form_delegate_details.html.haml
+++ b/app/views/spina/admin/conferences/delegates/_form_delegate_details.html.haml
@@ -35,4 +35,4 @@
         .horizontal-form-content.multiple.select-dropdown= f.collection_select :dietary_requirement_ids, Spina::Admin::Conferences::DietaryRequirement.all, :id, :name, {}, { multiple: true, required: false }
 
   - unless @delegate.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_delegate_path(@delegate), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', delegate: @delegate.full_name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_delegate_path(@delegate), method: :delete, data: { confirm: t('.delete_confirmation', delegate: @delegate.full_name) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/dietary_requirements/_form.html.haml
+++ b/app/views/spina/admin/conferences/dietary_requirements/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @dietary_requirement.errors
 
-= form_for @dietary_requirement, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @dietary_requirement, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/dietary_requirements/_form_dietary_requirement_details.html.haml
+++ b/app/views/spina/admin/conferences/dietary_requirements/_form_dietary_requirement_details.html.haml
@@ -6,4 +6,4 @@
         .horizontal-form-content= f.text_field :name, placeholder: Spina::Admin::Conferences::DietaryRequirement.human_attribute_name(:name), required: true
 
   - unless @dietary_requirement.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_dietary_requirement_path(@dietary_requirement), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', dietary_requirement: @dietary_requirement.name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_dietary_requirement_path(@dietary_requirement), method: :delete, data: { confirm: t('.delete_confirmation', dietary_requirement: @dietary_requirement.name) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/institutions/_form.html.haml
+++ b/app/views/spina/admin/conferences/institutions/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @institution.errors
 
-= form_for @institution, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @institution, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/institutions/_form_institution_details.html.haml
+++ b/app/views/spina/admin/conferences/institutions/_form_institution_details.html.haml
@@ -32,4 +32,4 @@
 
 
   - unless @institution.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_institution_path(@institution), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', institution: @institution.name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_institution_path(@institution), method: :delete, data: { confirm: t('.delete_confirmation', institution: @institution.name) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/presentation_attachment_types/_form.html.haml
+++ b/app/views/spina/admin/conferences/presentation_attachment_types/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @presentation_attachment_type.errors
 
-= form_for @presentation_attachment_type, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @presentation_attachment_type, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 
@@ -20,4 +20,4 @@
         .horizontal-form-content= f.text_field :name, placeholder: Spina::Admin::Conferences::DietaryRequirement.human_attribute_name(:name), required: true
 
   - unless @presentation_attachment_type.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_presentation_attachment_type_path(@presentation_attachment_type), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', presentation_attachment_type: @presentation_attachment_type.name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_presentation_attachment_type_path(@presentation_attachment_type), method: :delete, data: { confirm: t('.delete_confirmation', presentation_attachment_type: @presentation_attachment_type.name) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/presentation_types/_form.html.haml
+++ b/app/views/spina/admin/conferences/presentation_types/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @presentation_type.errors
 
-= form_for @presentation_type, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @presentation_type, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/presentation_types/_form_presentation_type_details.html.haml
+++ b/app/views/spina/admin/conferences/presentation_types/_form_presentation_type_details.html.haml
@@ -17,4 +17,4 @@
         .horizontal-form-content= f.number_field :minutes, value: @presentation_type.minutes, placeholder: Spina::Admin::Conferences::PresentationType.human_attribute_name(:duration), required: true, step: 5, min: 5
 
   - unless @presentation_type.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_presentation_type_path(@presentation_type), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', presentation_type: @presentation_type.name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_presentation_type_path(@presentation_type), method: :delete, data: { confirm: t('.delete_confirmation', presentation_type: @presentation_type.name) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/presentations/_form.html.haml
+++ b/app/views/spina/admin/conferences/presentations/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @presentation.errors
 
-= form_for @presentation, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @presentation, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/presentations/_form_presentation_details.html.haml
+++ b/app/views/spina/admin/conferences/presentations/_form_presentation_details.html.haml
@@ -52,4 +52,4 @@
                 = render 'attachment_fields', f: attachment_fields
 
   - unless @presentation.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_presentation_path(@presentation), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', presentation: @presentation.title) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_presentation_path(@presentation), method: :delete, data: { confirm: t('.delete_confirmation', presentation: @presentation.title) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/rooms/_form.html.haml
+++ b/app/views/spina/admin/conferences/rooms/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @room.errors
 
-= form_for @room, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @room, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/rooms/_form_room_details.html.haml
+++ b/app/views/spina/admin/conferences/rooms/_form_room_details.html.haml
@@ -15,4 +15,4 @@
         .horizontal-form-content= f.text_field :number, placeholder: Spina::Admin::Conferences::Room.human_attribute_name(:number), required: true
 
   - unless @room.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_room_path(@room), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', room: @room.name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_room_path(@room), method: :delete, data: { confirm: t('.delete_confirmation', room: @room.name) }, class: %w[button button-link button-danger]

--- a/app/views/spina/admin/conferences/sessions/_form.html.haml
+++ b/app/views/spina/admin/conferences/sessions/_form.html.haml
@@ -2,7 +2,7 @@
   - content_for :notifications do
     = render 'errors', errors: @session.errors
 
-= form_for @session, remote: true, html: { autocomplete: 'off' } do |f|
+= form_for @session, html: { autocomplete: 'off' } do |f|
   %header#header
     = render partial: 'spina/admin/shared/breadcrumbs'
 

--- a/app/views/spina/admin/conferences/sessions/_form_session_details.html.haml
+++ b/app/views/spina/admin/conferences/sessions/_form_session_details.html.haml
@@ -20,4 +20,4 @@
             .select-dropdown= f.collection_select :room_id, @session.institution.present? ? @session.institution.rooms : Spina::Admin::Conferences::Institution.first.rooms, :id, :name, { include_blank: true }, required: true, data: {'spina--admin--conferences--select_options_target': 'select', text_key: 'name', key_path: 'rooms' }
 
   - unless @session.new_record?
-    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_session_path(@session), method: :delete, remote: true, data: { confirm: t('.delete_confirmation', session: @session.name) }, class: %w[button button-link button-danger]
+    .pull-right= link_to t('spina.permanently_delete'), admin_conferences_session_path(@session), method: :delete, data: { confirm: t('.delete_confirmation', session: @session.name) }, class: %w[button button-link button-danger]

--- a/test/controllers/spina/admin/conferences/conferences_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/conferences_controller_test.rb
@@ -75,7 +75,7 @@ module Spina
           attributes[:finish_date] = @conference.finish_date
           attributes[:name] = @conference.name
           assert_difference 'Conference.count' do
-            post admin_conferences_conferences_url, params: { admin_conferences_conference: attributes }, xhr: true
+            post admin_conferences_conferences_url, params: { admin_conferences_conference: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_conferences_url
           assert_equal 'Conference saved', flash[:success]
@@ -99,7 +99,7 @@ module Spina
           attributes[:finish_date] = @invalid_conference.finish_date
           attributes[:name] = @invalid_conference.name
           assert_no_difference 'Conference.count' do
-            post admin_conferences_conferences_url, params: { admin_conferences_conference: attributes }, xhr: true
+            post admin_conferences_conferences_url, params: { admin_conferences_conference: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Conference saved', flash[:success]
@@ -120,7 +120,7 @@ module Spina
           attributes[:start_date] = @conference.start_date
           attributes[:finish_date] = @conference.finish_date
           attributes[:name] = @conference.name
-          patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, xhr: true
+          patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_conferences_url
           assert_equal 'Conference saved', flash[:success]
         end
@@ -140,7 +140,7 @@ module Spina
           attributes[:start_date] = @invalid_conference.start_date
           attributes[:finish_date] = @invalid_conference.finish_date
           attributes[:name] = @invalid_conference.name
-          patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, xhr: true
+          patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Conference saved', flash[:success]
         end
@@ -155,7 +155,7 @@ module Spina
 
         test 'should destroy conference with remote form' do
           assert_difference 'Conference.count', -1 do
-            delete admin_conferences_conference_url(@empty_conference), xhr: true
+            delete admin_conferences_conference_url(@empty_conference), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_conferences_url
           assert_equal 'Conference deleted', flash[:success]
@@ -171,7 +171,7 @@ module Spina
 
         test 'should fail to destroy conference with dependent records with remote form' do
           assert_no_difference 'Conference.count' do
-            delete admin_conferences_conference_url(@conference), xhr: true
+            delete admin_conferences_conference_url(@conference), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Conference deleted', flash[:success]
@@ -186,7 +186,7 @@ module Spina
           attributes[:parts_attributes].find { |part| part['name'] == 'submission_text' }
                                        .then { |part| part['partable_attributes']['content'] = 'Dolor sit amen' }
           assert_changes -> { @conference.content('submission_text') }, from: 'Lorem ipsum dolor sit amet', to: 'Dolor sit amen' do
-            patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, xhr: true
+            patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, as: :turbo_stream
           end
         end
 
@@ -212,7 +212,7 @@ module Spina
           end
           assert_changes -> { @conference.content('sponsors').structure_items.first.content('name') },
                          from: 'Lorem ipsum dolor sit amet', to: 'Test' do
-            patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, xhr: true
+            patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, as: :turbo_stream
           end
         end
 
@@ -239,7 +239,7 @@ module Spina
           end
           assert_changes -> { @conference.content('sponsors').structure_items.first.content('logo') },
                          from: @dubrovnik_image, to: @rovinj_image do
-            patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, xhr: true
+            patch admin_conferences_conference_url(@conference), params: { admin_conferences_conference: attributes }, as: :turbo_stream
           end
         end
 

--- a/test/controllers/spina/admin/conferences/delegates_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/delegates_controller_test.rb
@@ -56,7 +56,7 @@ module Spina
           attributes = @delegate.attributes
           attributes[:conference_ids] = @delegate.conference_ids
           assert_difference 'Delegate.count' do
-            post admin_conferences_delegates_url, params: { admin_conferences_delegate: attributes }, xhr: true
+            post admin_conferences_delegates_url, params: { admin_conferences_delegate: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_delegates_url
           assert_equal 'Delegate saved', flash[:success]
@@ -76,7 +76,7 @@ module Spina
           attributes = @invalid_delegate.attributes
           attributes[:conference_ids] = @invalid_delegate.conference_ids
           assert_no_difference 'Delegate.count' do
-            post admin_conferences_delegates_url, params: { admin_conferences_delegate: attributes }, xhr: true
+            post admin_conferences_delegates_url, params: { admin_conferences_delegate: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Delegate saved', flash[:success]
@@ -94,7 +94,7 @@ module Spina
           attributes = @delegate.attributes
           attributes[:conference_ids] = @delegate.conference_ids
           patch admin_conferences_delegate_url(@delegate), params: { admin_conferences_delegate: attributes },
-                                                           xhr: true
+                                                           as: :turbo_stream
           assert_redirected_to admin_conferences_delegates_url
           assert_equal 'Delegate saved', flash[:success]
         end
@@ -110,7 +110,7 @@ module Spina
         test 'should fail to update invalid delegate with remote form' do
           attributes = @invalid_delegate.attributes
           attributes[:conference_ids] = @invalid_delegate.conference_ids
-          patch admin_conferences_delegate_url(@delegate), params: { admin_conferences_delegate: attributes }, xhr: true
+          patch admin_conferences_delegate_url(@delegate), params: { admin_conferences_delegate: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Delegate saved', flash[:success]
         end
@@ -125,7 +125,7 @@ module Spina
 
         test 'should destroy delegate with remote form' do
           assert_difference 'Delegate.count', -1 do
-            delete admin_conferences_delegate_url(@delegate), xhr: true
+            delete admin_conferences_delegate_url(@delegate), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_delegates_url
           assert_equal 'Delegate deleted', flash[:success]
@@ -146,7 +146,7 @@ module Spina
           callbacks = Delegate._destroy_callbacks
           Delegate.before_destroy { throw :abort }
           assert_no_difference 'Delegate.count' do
-            delete admin_conferences_delegate_url(@delegate), xhr: true
+            delete admin_conferences_delegate_url(@delegate), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Delegate deleted', flash[:success]

--- a/test/controllers/spina/admin/conferences/dietary_requirements_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/dietary_requirements_controller_test.rb
@@ -51,7 +51,7 @@ module Spina
           attributes = @dietary_requirement.attributes
           attributes[:name] = @dietary_requirement.name
           assert_difference 'DietaryRequirement.count' do
-            post admin_conferences_dietary_requirements_url, params: { admin_conferences_dietary_requirement: attributes }, xhr: true
+            post admin_conferences_dietary_requirements_url, params: { admin_conferences_dietary_requirement: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_dietary_requirements_url
           assert_equal 'Dietary requirement saved', flash[:success]
@@ -71,7 +71,7 @@ module Spina
           attributes = @invalid_dietary_requirement.attributes
           attributes[:name] = @invalid_dietary_requirement.name
           assert_no_difference 'DietaryRequirement.count' do
-            post admin_conferences_dietary_requirements_url, params: { admin_conferences_dietary_requirement: attributes }, xhr: true
+            post admin_conferences_dietary_requirements_url, params: { admin_conferences_dietary_requirement: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Dietary requirement saved', flash[:success]
@@ -90,7 +90,7 @@ module Spina
           attributes = @dietary_requirement.attributes
           attributes[:name] = @dietary_requirement.name
           patch admin_conferences_dietary_requirement_url(@dietary_requirement),
-                params: { admin_conferences_dietary_requirement: attributes }, xhr: true
+                params: { admin_conferences_dietary_requirement: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_dietary_requirements_url
           assert_equal 'Dietary requirement saved', flash[:success]
         end
@@ -108,7 +108,7 @@ module Spina
           attributes = @invalid_dietary_requirement.attributes
           attributes[:name] = @invalid_dietary_requirement.name
           patch admin_conferences_dietary_requirement_url(@dietary_requirement),
-                params: { admin_conferences_dietary_requirement: attributes }, xhr: true
+                params: { admin_conferences_dietary_requirement: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Dietary requirement saved', flash[:success]
         end
@@ -123,7 +123,7 @@ module Spina
 
         test 'should destroy dietary requirement with remote form' do
           assert_difference 'DietaryRequirement.count', -1 do
-            delete admin_conferences_dietary_requirement_url(@dietary_requirement), xhr: true
+            delete admin_conferences_dietary_requirement_url(@dietary_requirement), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_dietary_requirements_url
           assert_equal 'Dietary requirement deleted', flash[:success]
@@ -144,7 +144,7 @@ module Spina
           callbacks = DietaryRequirement._destroy_callbacks
           DietaryRequirement.before_destroy { throw :abort }
           assert_no_difference 'DietaryRequirement.count' do
-            delete admin_conferences_dietary_requirement_url(@dietary_requirement), xhr: true
+            delete admin_conferences_dietary_requirement_url(@dietary_requirement), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Dietary requirement deleted', flash[:success]

--- a/test/controllers/spina/admin/conferences/institutions_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/institutions_controller_test.rb
@@ -59,7 +59,7 @@ module Spina
           attributes[:name] = @institution.name
           attributes[:city] = @institution.city
           assert_difference 'Institution.count' do
-            post admin_conferences_institutions_url, params: { admin_conferences_institution: attributes }, xhr: true
+            post admin_conferences_institutions_url, params: { admin_conferences_institution: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_institutions_url
           assert_equal 'Institution saved', flash[:success]
@@ -81,7 +81,7 @@ module Spina
           attributes[:name] = @invalid_institution.name
           attributes[:city] = @invalid_institution.city
           assert_no_difference 'Institution.count' do
-            post admin_conferences_institutions_url, params: { admin_conferences_institution: attributes }, xhr: true
+            post admin_conferences_institutions_url, params: { admin_conferences_institution: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Institution saved', flash[:success]
@@ -100,7 +100,7 @@ module Spina
           attributes = @institution.attributes
           attributes[:name] = @institution.name
           attributes[:city] = @institution.city
-          patch admin_conferences_institution_url(@institution), params: { admin_conferences_institution: attributes }, xhr: true
+          patch admin_conferences_institution_url(@institution), params: { admin_conferences_institution: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_institutions_url
           assert_equal 'Institution saved', flash[:success]
         end
@@ -118,7 +118,7 @@ module Spina
           attributes = @invalid_institution.attributes
           attributes[:name] = @invalid_institution.name
           attributes[:city] = @invalid_institution.city
-          patch admin_conferences_institution_url(@institution), params: { admin_conferences_institution: attributes }, xhr: true
+          patch admin_conferences_institution_url(@institution), params: { admin_conferences_institution: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Institution saved', flash[:success]
         end
@@ -133,7 +133,7 @@ module Spina
 
         test 'should destroy institution with remote form' do
           assert_difference 'Institution.count', -1 do
-            delete admin_conferences_institution_url(@empty_institution), xhr: true
+            delete admin_conferences_institution_url(@empty_institution), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_institutions_url
           assert_equal 'Institution deleted', flash[:success]
@@ -149,7 +149,7 @@ module Spina
 
         test 'should fail to destroy institution with dependent records with remote form' do
           assert_no_difference 'Institution.count' do
-            delete admin_conferences_institution_url(@institution), xhr: true
+            delete admin_conferences_institution_url(@institution), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Institution deleted', flash[:success]

--- a/test/controllers/spina/admin/conferences/presentation_attachment_types_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/presentation_attachment_types_controller_test.rb
@@ -46,7 +46,7 @@ module Spina
           attributes[:name] = @presentation_attachment_type.name
           assert_difference 'PresentationAttachmentType.count' do
             post admin_conferences_presentation_attachment_types_url,
-                 params: { admin_conferences_presentation_attachment_type: attributes }, xhr: true
+                 params: { admin_conferences_presentation_attachment_type: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_presentation_attachment_types_url
           assert_equal 'Presentation attachment type saved', flash[:success]
@@ -67,7 +67,7 @@ module Spina
           attributes[:name] = @invalid_presentation_attachment_type.name
           assert_no_difference 'PresentationAttachmentType.count' do
             post admin_conferences_presentation_attachment_types_url,
-                 params: { admin_conferences_presentation_attachment_type: attributes }, xhr: true
+                 params: { admin_conferences_presentation_attachment_type: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Presentation attachment type saved', flash[:success]
@@ -86,7 +86,7 @@ module Spina
           attributes = @presentation_attachment_type.attributes
           attributes[:name] = @presentation_attachment_type.name
           patch admin_conferences_presentation_attachment_type_url(@presentation_attachment_type),
-                params: { admin_conferences_presentation_attachment_type: attributes }, xhr: true
+                params: { admin_conferences_presentation_attachment_type: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_presentation_attachment_types_url
           assert_equal 'Presentation attachment type saved', flash[:success]
         end
@@ -104,7 +104,7 @@ module Spina
           attributes = @invalid_presentation_attachment_type.attributes
           attributes[:name] = @invalid_presentation_attachment_type.name
           patch admin_conferences_presentation_attachment_type_url(@presentation_attachment_type),
-                params: { admin_conferences_presentation_attachment_type: attributes }, xhr: true
+                params: { admin_conferences_presentation_attachment_type: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Presentation attachment type saved', flash[:success]
         end
@@ -119,7 +119,7 @@ module Spina
 
         test 'should destroy presentation attachment type with remote form' do
           assert_difference 'PresentationAttachmentType.count', -1 do
-            delete admin_conferences_presentation_attachment_type_url(@presentation_attachment_type), xhr: true
+            delete admin_conferences_presentation_attachment_type_url(@presentation_attachment_type), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_presentation_attachment_types_url
           assert_equal 'Presentation attachment type deleted', flash[:success]
@@ -140,7 +140,7 @@ module Spina
           callbacks = PresentationAttachmentType._destroy_callbacks
           PresentationAttachmentType.before_destroy { throw :abort }
           assert_no_difference 'PresentationAttachmentType.count' do
-            delete admin_conferences_presentation_attachment_type_url(@presentation_attachment_type), xhr: true
+            delete admin_conferences_presentation_attachment_type_url(@presentation_attachment_type), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Presentation attachment type deleted', flash[:success]

--- a/test/controllers/spina/admin/conferences/presentation_types_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/presentation_types_controller_test.rb
@@ -54,7 +54,7 @@ module Spina
           attributes[:minutes] = @presentation_type.minutes
           attributes[:name] = @presentation_type.name
           assert_difference 'PresentationType.count' do
-            post admin_conferences_presentation_types_url, params: { admin_conferences_presentation_type: attributes }, xhr: true
+            post admin_conferences_presentation_types_url, params: { admin_conferences_presentation_type: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_presentation_types_url
           assert_equal 'Presentation type saved', flash[:success]
@@ -76,7 +76,7 @@ module Spina
           attributes[:minutes] = @invalid_presentation_type.minutes
           attributes[:name] = @invalid_presentation_type.name
           assert_no_difference 'PresentationType.count' do
-            post admin_conferences_presentation_types_url, params: { admin_conferences_presentation_type: attributes }, xhr: true
+            post admin_conferences_presentation_types_url, params: { admin_conferences_presentation_type: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Presentation type saved', flash[:success]
@@ -96,7 +96,7 @@ module Spina
           attributes[:minutes] = @presentation_type.minutes
           attributes[:name] = @presentation_type.name
           patch admin_conferences_presentation_type_url(@presentation_type),
-                params: { admin_conferences_presentation_type: attributes }, xhr: true
+                params: { admin_conferences_presentation_type: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_presentation_types_url
           assert_equal 'Presentation type saved', flash[:success]
         end
@@ -115,7 +115,7 @@ module Spina
           attributes[:minutes] = @invalid_presentation_type.minutes
           attributes[:name] = @invalid_presentation_type.name
           patch admin_conferences_presentation_type_url(@presentation_type),
-                params: { admin_conferences_presentation_type: attributes }, xhr: true
+                params: { admin_conferences_presentation_type: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Presentation type saved', flash[:success]
         end
@@ -130,7 +130,7 @@ module Spina
 
         test 'should destroy presentation type with remote form' do
           assert_difference 'PresentationType.count', -1 do
-            delete admin_conferences_presentation_type_url(@empty_presentation_type), xhr: true
+            delete admin_conferences_presentation_type_url(@empty_presentation_type), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_presentation_types_url
           assert_equal 'Presentation type deleted', flash[:success]
@@ -146,7 +146,7 @@ module Spina
 
         test 'should fail to destroy presentation type with dependent records with remote form' do
           assert_no_difference 'PresentationType.count' do
-            delete admin_conferences_presentation_type_url(@presentation_type), xhr: true
+            delete admin_conferences_presentation_type_url(@presentation_type), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Presentation type deleted', flash[:success]

--- a/test/controllers/spina/admin/conferences/presentations_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/presentations_controller_test.rb
@@ -59,7 +59,7 @@ module Spina
           attributes[:title] = @presentation.title
           attributes[:abstract] = @presentation.abstract
           assert_difference 'Presentation.count' do
-            post admin_conferences_presentations_url, params: { admin_conferences_presentation: attributes }, xhr: true
+            post admin_conferences_presentations_url, params: { admin_conferences_presentation: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_presentations_url
           assert_equal 'Presentation saved', flash[:success]
@@ -87,7 +87,7 @@ module Spina
           attributes[:title] = @invalid_presentation.title
           attributes[:abstract] = @invalid_presentation.abstract
           assert_no_difference 'Presentation.count' do
-            post admin_conferences_presentations_url, params: { admin_conferences_presentation: attributes }, xhr: true
+            post admin_conferences_presentations_url, params: { admin_conferences_presentation: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Presentation saved', flash[:success]
@@ -112,7 +112,7 @@ module Spina
           attributes[:date] = @presentation.date
           attributes[:title] = @presentation.title
           attributes[:abstract] = @presentation.abstract
-          patch admin_conferences_presentation_url(@presentation), params: { admin_conferences_presentation: attributes }, xhr: true
+          patch admin_conferences_presentation_url(@presentation), params: { admin_conferences_presentation: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_presentations_url
           assert_equal 'Presentation saved', flash[:success]
         end
@@ -136,7 +136,7 @@ module Spina
           attributes[:date] = @invalid_presentation.date
           attributes[:title] = @invalid_presentation.title
           attributes[:abstract] = @invalid_presentation.abstract
-          patch admin_conferences_presentation_url(@presentation), params: { admin_conferences_presentation: attributes }, xhr: true
+          patch admin_conferences_presentation_url(@presentation), params: { admin_conferences_presentation: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Presentation saved', flash[:success]
         end
@@ -151,7 +151,7 @@ module Spina
 
         test 'should destroy presentation with remote form' do
           assert_difference 'Presentation.count', -1 do
-            delete admin_conferences_presentation_url(@presentation), xhr: true
+            delete admin_conferences_presentation_url(@presentation), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_presentations_url
           assert_equal 'Presentation deleted', flash[:success]
@@ -172,7 +172,7 @@ module Spina
           callbacks = Presentation._destroy_callbacks
           Presentation.before_destroy { throw :abort }
           assert_no_difference 'Presentation.count' do
-            delete admin_conferences_presentation_url(@presentation), xhr: true
+            delete admin_conferences_presentation_url(@presentation), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Presentation deleted', flash[:success]

--- a/test/controllers/spina/admin/conferences/rooms_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/rooms_controller_test.rb
@@ -53,7 +53,7 @@ module Spina
           attributes[:building] = @room.building
           attributes[:number] = @room.number
           assert_difference 'Room.count' do
-            post admin_conferences_rooms_url, params: { admin_conferences_room: attributes }, xhr: true
+            post admin_conferences_rooms_url, params: { admin_conferences_room: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_rooms_url
           assert_equal 'Room saved', flash[:success]
@@ -75,7 +75,7 @@ module Spina
           attributes[:building] = @invalid_room.building
           attributes[:number] = @invalid_room.number
           assert_no_difference 'Room.count' do
-            post admin_conferences_rooms_url, params: { admin_conferences_room: attributes }, xhr: true
+            post admin_conferences_rooms_url, params: { admin_conferences_room: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Room saved', flash[:success]
@@ -94,7 +94,7 @@ module Spina
           attributes = @room.attributes
           attributes[:building] = @room.building
           attributes[:number] = @room.number
-          patch admin_conferences_room_url(@room), params: { admin_conferences_room: attributes }, xhr: true
+          patch admin_conferences_room_url(@room), params: { admin_conferences_room: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_rooms_url
           assert_equal 'Room saved', flash[:success]
         end
@@ -112,7 +112,7 @@ module Spina
           attributes = @invalid_room.attributes
           attributes[:building] = @invalid_room.building
           attributes[:number] = @invalid_room.number
-          patch admin_conferences_room_url(@room), params: { admin_conferences_room: attributes }, xhr: true
+          patch admin_conferences_room_url(@room), params: { admin_conferences_room: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Room saved', flash[:success]
         end
@@ -127,7 +127,7 @@ module Spina
 
         test 'should destroy room with remote form' do
           assert_difference 'Room.count', -1 do
-            delete admin_conferences_room_url(@empty_room), xhr: true
+            delete admin_conferences_room_url(@empty_room), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_rooms_url
           assert_equal 'Room deleted', flash[:success]
@@ -143,7 +143,7 @@ module Spina
 
         test 'should fail to destroy room with dependent records with remote form' do
           assert_no_difference 'Room.count' do
-            delete admin_conferences_room_url(@room), xhr: true
+            delete admin_conferences_room_url(@room), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Room deleted', flash[:success]

--- a/test/controllers/spina/admin/conferences/sessions_controller_test.rb
+++ b/test/controllers/spina/admin/conferences/sessions_controller_test.rb
@@ -51,7 +51,7 @@ module Spina
           attributes = @session.attributes
           attributes[:name] = @session.name
           assert_difference 'Session.count' do
-            post admin_conferences_sessions_url, params: { admin_conferences_session: attributes }, xhr: true
+            post admin_conferences_sessions_url, params: { admin_conferences_session: attributes }, as: :turbo_stream
           end
           assert_redirected_to admin_conferences_sessions_url
           assert_equal 'Session saved', flash[:success]
@@ -71,7 +71,7 @@ module Spina
           attributes = @invalid_session.attributes
           attributes[:name] = @invalid_session.name
           assert_no_difference 'Session.count' do
-            post admin_conferences_sessions_url, params: { admin_conferences_session: attributes }, xhr: true
+            post admin_conferences_sessions_url, params: { admin_conferences_session: attributes }, as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Session saved', flash[:success]
@@ -88,7 +88,7 @@ module Spina
         test 'should update session with remote form' do
           attributes = @session.attributes
           attributes[:name] = @session.name
-          patch admin_conferences_session_url(@session), params: { admin_conferences_session: attributes }, xhr: true
+          patch admin_conferences_session_url(@session), params: { admin_conferences_session: attributes }, as: :turbo_stream
           assert_redirected_to admin_conferences_sessions_url
           assert_equal 'Session saved', flash[:success]
         end
@@ -104,7 +104,7 @@ module Spina
         test 'should fail to update invalid session with remote form' do
           attributes = @invalid_session.attributes
           attributes[:name] = @invalid_session.name
-          patch admin_conferences_session_url(@session), params: { admin_conferences_session: attributes }, xhr: true
+          patch admin_conferences_session_url(@session), params: { admin_conferences_session: attributes }, as: :turbo_stream
           assert_response :success
           assert_not_equal 'Session saved', flash[:success]
         end
@@ -119,7 +119,7 @@ module Spina
 
         test 'should destroy session with remote form' do
           assert_difference 'Session.count', -1 do
-            delete admin_conferences_session_url(@empty_session), xhr: true
+            delete admin_conferences_session_url(@empty_session), as: :turbo_stream
           end
           assert_redirected_to admin_conferences_sessions_url
           assert_equal 'Session deleted', flash[:success]
@@ -135,7 +135,7 @@ module Spina
 
         test 'should fail to destroy session with dependent records with remote form' do
           assert_no_difference 'Session.count' do
-            delete admin_conferences_session_url(@session), xhr: true
+            delete admin_conferences_session_url(@session), as: :turbo_stream
           end
           assert_response :success
           assert_not_equal 'Session deleted', flash[:success]


### PR DESCRIPTION
This PR switches to rendering errors with Turbo streams, and submitting forms with Turbo drive rather than UJS. More of this to come…