### PR TITLE
Add timezone support to calendar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     spina-admin-conferences (2.0.1)
       icalendar (~> 2.5)
+      mobility-actiontext (= 0.2.0)
       rails (~> 6.0)
       rails-i18n (~> 6.0)
       redis (~> 4.2)
@@ -180,6 +181,9 @@ GEM
     mobility (1.1.1)
       i18n (>= 0.6.10, < 2)
       request_store (~> 1.0)
+    mobility-actiontext (0.2.0)
+      mobility (~> 1.1)
+      rails (~> 6.0)
     nio4r (2.5.7)
     nokogiri (1.11.2)
       mini_portile2 (~> 2.5.0)

--- a/app/models/spina/admin/conferences/conference.rb
+++ b/app/models/spina/admin/conferences/conference.rb
@@ -137,12 +137,6 @@ module Spina
           event.summary = name
           event
         end
-
-        # @param (see #to_event)
-        # @deprecated Use {#to_event} instead
-        def to_ics
-          to_event
-        end
       end
     end
   end

--- a/app/models/spina/admin/conferences/conference.rb
+++ b/app/models/spina/admin/conferences/conference.rb
@@ -147,10 +147,8 @@ module Spina
           event = Icalendar::Event.new
           return event if invalid?
 
-          event.dtstart = start_date
-          event.dtstart.ical_param(:value, 'DATE')
-          event.dtend = finish_date
-          event.dtend.ical_param(:value, 'DATE')
+          event.dtstart = Icalendar::Values::Date.new(dates.begin)
+          event.dtend = Icalendar::Values::Date.new(dates.exclude_end? ? dates.end : dates.end + 1.day)
           event.location = location
           event.contact = Spina::Account.first.email
           event.categories = Conference.model_name.human(count: 0)

--- a/app/models/spina/admin/conferences/event.rb
+++ b/app/models/spina/admin/conferences/event.rb
@@ -71,12 +71,6 @@ module Spina
           event.description = description.try(:gsub, %r{</?[^>]*>}, '')
           event
         end
-
-        # @param (see #to_event)
-        # @deprecated Use {#to_event} instead
-        def to_ics
-          to_event
-        end
       end
     end
   end

--- a/app/models/spina/admin/conferences/event.rb
+++ b/app/models/spina/admin/conferences/event.rb
@@ -68,8 +68,8 @@ module Spina
           event = Icalendar::Event.new
           return event if invalid?
 
-          event.dtstart = start_datetime
-          event.dtend = finish_datetime
+          event.dtstart = Icalendar::Values::DateTime.new(start_datetime, tzid: start_datetime.time_zone.tzinfo.name)
+          event.dtend = Icalendar::Values::DateTime.new(finish_datetime, tzid: start_datetime.time_zone.tzinfo.name)
           event.location = location
           event.contact = Spina::Account.first.email
           event.categories = Event.model_name.human(count: 0)

--- a/app/models/spina/admin/conferences/event.rb
+++ b/app/models/spina/admin/conferences/event.rb
@@ -56,6 +56,13 @@ module Spina
           start_datetime.to_date
         end
 
+        # @return [TZInfo::TimezonePeriod, nil] the time zone period for the event
+        def time_zone_period
+          return if start_datetime.blank?
+
+          start_datetime.period
+        end
+
         # @return [Icalendar::Event] the event as an iCal event
         def to_event # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           event = Icalendar::Event.new

--- a/app/models/spina/admin/conferences/event.rb
+++ b/app/models/spina/admin/conferences/event.rb
@@ -20,14 +20,15 @@ module Spina
         # @!attribute [rw] name
         #   @return [String, nil] the translated name of the event
         # @!attribute [rw] description
-        #   @return [String, nil] the translated description of the event
+        #   @return [ActionText::RichText, nil] the translated description of the event
         # @!attribute [rw] start_datetime
         #   @return [ActiveSupport::TimeWithZone, nil] the start time of the event
         # @!attribute [rw] finish_datetime
         #   @return [ActiveSupport::TimeWithZone, nil] the finish time of the event
         # @!attribute [rw] location
         #   @return [String, nil] the translated location of the event
-        translates :name, :description, :location, fallbacks: true
+        translates :name, :location, fallbacks: true
+        translates :description, backend: :action_text, fallbacks: true
 
         # @return [ActiveRecord::Relation] all events, ordered by name
         scope :sorted, -> { i18n.order :name }
@@ -74,8 +75,8 @@ module Spina
           event.contact = Spina::Account.first.email
           event.categories = Event.model_name.human(count: 0)
           event.summary = name
-          event.append_custom_property('alt_description', description.try(:html_safe))
-          event.description = description.try(:gsub, %r{</?[^>]*>}, '')
+          event.append_custom_property('alt_description', description.to_s)
+          event.description = description.try(:to_plain_text)
           event
         end
       end

--- a/app/models/spina/admin/conferences/presentation.rb
+++ b/app/models/spina/admin/conferences/presentation.rb
@@ -98,13 +98,20 @@ module Spina
           start_datetime.to_date
         end
 
+        # @return [ActiveSupport::TimeWithZone, nil] the presentation end time. Nil if the presentation has no start date and time
+        def finish_datetime
+          return if start_datetime.blank?
+
+          start_datetime + presentation_type.duration
+        end
+
         # @return [Icalendar::Event] the presentation as an iCal event
         def to_event # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           event = Icalendar::Event.new
           return event if invalid?
 
           event.dtstart = start_datetime
-          event.dtend = start_datetime + presentation_type.duration
+          event.dtend = finish_datetime
           event.location = session.room_name
           presenters.each { |presenter| event.contact = presenter.full_name_and_institution }
           event.categories = Presentation.model_name.human(count: 0)

--- a/app/models/spina/admin/conferences/presentation.rb
+++ b/app/models/spina/admin/conferences/presentation.rb
@@ -117,8 +117,8 @@ module Spina
           event = Icalendar::Event.new
           return event if invalid?
 
-          event.dtstart = start_datetime
-          event.dtend = finish_datetime
+          event.dtstart = Icalendar::Values::DateTime.new(start_datetime, tzid: start_datetime.time_zone.tzinfo.name)
+          event.dtend = Icalendar::Values::DateTime.new(finish_datetime, tzid: finish_datetime.time_zone.tzinfo.name)
           event.location = session.room_name
           presenters.each { |presenter| event.contact = presenter.full_name_and_institution }
           event.categories = Presentation.model_name.human(count: 0)

--- a/app/models/spina/admin/conferences/presentation.rb
+++ b/app/models/spina/admin/conferences/presentation.rb
@@ -105,6 +105,13 @@ module Spina
           start_datetime + presentation_type.duration
         end
 
+        # @return [TZInfo::TimezonePeriod, nil] the time zone period for the presentation
+        def time_zone_period
+          return if start_datetime.blank?
+
+          start_datetime.period
+        end
+
         # @return [Icalendar::Event] the presentation as an iCal event
         def to_event # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
           event = Icalendar::Event.new

--- a/app/models/spina/admin/conferences/presentation.rb
+++ b/app/models/spina/admin/conferences/presentation.rb
@@ -28,8 +28,9 @@ module Spina
         # @!attribute [rw] title
         #   @return [String, nil] the presentation title
         # @!attribute [rw] abstract
-        #   @return [String, nil] the presentation abstract
-        translates :title, :abstract, fallbacks: true
+        #   @return [ActionText::RichText, nil] the presentation abstract
+        translates :title, fallbacks: true
+        translates :abstract, backend: :action_text, fallbacks: true
 
         # @return [ActiveRecord::Relation] all conferences, ordered by date
         scope :sorted, -> { order start_datetime: :desc }
@@ -123,8 +124,8 @@ module Spina
           presenters.each { |presenter| event.contact = presenter.full_name_and_institution }
           event.categories = Presentation.model_name.human(count: 0)
           event.summary = title
-          event.append_custom_property('alt_description', abstract.try(:html_safe))
-          event.description = abstract.try(:gsub, %r{</?[^>]*>}, '')
+          event.append_custom_property('alt_description', abstract.to_s)
+          event.description = abstract.try(:to_plain_text)
           event
         end
       end

--- a/app/models/spina/admin/conferences/presentation.rb
+++ b/app/models/spina/admin/conferences/presentation.rb
@@ -113,12 +113,6 @@ module Spina
           event.description = abstract.try(:gsub, %r{</?[^>]*>}, '')
           event
         end
-
-        # @param (see #to_event)
-        # @deprecated Use {#to_event} instead
-        def to_ics
-          to_event
-        end
       end
     end
   end

--- a/app/views/spina/admin/conferences/conferences/_event_fields.html.haml
+++ b/app/views/spina/admin/conferences/conferences/_event_fields.html.haml
@@ -22,8 +22,7 @@
   .structure-form-part
     .page-form-label= Spina::Admin::Conferences::Event.human_attribute_name :description
     .page-form-content
-      .page-form-rich-text
-        = render 'spina/admin/shared/rich_text_field', f: f, field: :description
+      .page-form-rich-text= f.rich_text_area :description
 
   = f.hidden_field :id
 

--- a/app/views/spina/admin/conferences/presentations/_form_presentation_details.html.haml
+++ b/app/views/spina/admin/conferences/presentations/_form_presentation_details.html.haml
@@ -23,8 +23,7 @@
   .page-form-group
     .page-form-label= Spina::Admin::Conferences::Presentation.human_attribute_name :abstract
     .page-form-content
-      .page-form-rich-text
-        = render 'spina/admin/shared/rich_text_field', f: f, field: :abstract
+      .page-form-rich-text= f.rich_text_area :abstract
 
   .page-form-group
     .page-form-label= Spina::Admin::Conferences::Presentation.human_attribute_name :presenters

--- a/db/migrate/20210417102513_add_locale_to_action_text_rich_texts.rb
+++ b/db/migrate/20210417102513_add_locale_to_action_text_rich_texts.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddLocaleToActionTextRichTexts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :action_text_rich_texts, :locale, :string
+    remove_index :action_text_rich_texts, column: [:record_type, :record_id, :name], name: :index_action_text_rich_texts_uniqueness,
+                                          unique: true
+    add_index :action_text_rich_texts, [:record_type, :record_id, :name, :locale], name: :index_action_text_rich_texts_uniqueness,
+                                                                                   unique: true
+  end
+end

--- a/db/migrate/20210417102513_add_locale_to_action_text_rich_texts.rb
+++ b/db/migrate/20210417102513_add_locale_to_action_text_rich_texts.rb
@@ -3,9 +3,9 @@
 class AddLocaleToActionTextRichTexts < ActiveRecord::Migration[6.1]
   def change
     add_column :action_text_rich_texts, :locale, :string
-    remove_index :action_text_rich_texts, column: [:record_type, :record_id, :name], name: :index_action_text_rich_texts_uniqueness,
+    remove_index :action_text_rich_texts, column: %i[record_type record_id name], name: :index_action_text_rich_texts_uniqueness,
                                           unique: true
-    add_index :action_text_rich_texts, [:record_type, :record_id, :name, :locale], name: :index_action_text_rich_texts_uniqueness,
-                                                                                   unique: true
+    add_index :action_text_rich_texts, %i[record_type record_id name locale], name: :index_action_text_rich_texts_uniqueness,
+                                                                              unique: true
   end
 end

--- a/db/migrate/20210417102514_move_texts_to_action_text_rich_texts.rb
+++ b/db/migrate/20210417102514_move_texts_to_action_text_rich_texts.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+class MoveTextsToActionTextRichTexts < ActiveRecord::Migration[6.1]
+  def up
+    create_table :mobility_text_translations do |t|
+      t.string :record
+    end
+    create_table :mobility_string_translations do |t|
+      t.string :record
+    end
+
+    Spina.config.locales.each do |locale|
+      I18n.with_locale(locale) do
+        Spina::Admin::Conferences::PresentationTranslation.where(locale: locale).in_batches.each_record do |presentation_translation|
+          presentation_translation.presentation.update(abstract: presentation_translation.abstract)
+        end
+        Spina::Admin::Conferences::EventTranslation.where(locale: locale).in_batches.each_record do |event_translation|
+          event_translation.event.update(description: event_translation.description)
+        end
+      end
+    end
+
+    remove_column :spina_conferences_presentation_translations, :abstract
+    remove_column :spina_conferences_event_translations, :description
+  end
+
+  def down
+    add_column :spina_conferences_presentation_translations, :abstract, :text
+    add_column :spina_conferences_event_translations, :description, :text
+
+    Spina.config.locales.each do |locale|
+      I18n.with_locale(locale) do
+        Spina::Admin::Conferences::PresentationTranslation.where(locale: locale).in_batches.each_record do |presentation_translation|
+          rich_text = ActionText::RichText.find_by(record: presentation_translation.presentation, name: 'abstract')
+          if rich_text
+            presentation_translation.update(abstract: rich_text.read_attribute_before_type_cast('body'))
+            rich_text.destroy
+          end
+        end
+        Spina::Admin::Conferences::EventTranslation.where(locale: locale).in_batches.each_record do |event_translation|
+          rich_text = ActionText::RichText.find_by(record: event_translation.event, name: 'description')
+          if rich_text
+            event_translation.update(description: rich_text.read_attribute_before_type_cast('body'))
+            rich_text.destroy
+          end
+        end
+      end
+    end
+
+    change_column_null :spina_conferences_presentation_translations, :abstract, false
+    change_column_null :spina_conferences_event_translations, :description, false
+    drop_table :mobility_text_translations
+    drop_table :mobility_string_translations
+  end
+end
+
+module Spina
+  module Admin
+    module Conferences
+      class PresentationTranslation < ApplicationRecord
+        belongs_to :presentation, foreign_key: 'spina_conferences_presentation_id'
+      end
+
+      class EventTranslation < ApplicationRecord
+        belongs_to :event, foreign_key: 'spina_conferences_event_id'
+      end
+
+      class Presentation < ApplicationRecord
+        has_many :presentation_translations, foreign_key: 'spina_conferences_presentation_id'
+
+        translates :abstract, backend: :action_text
+      end
+
+      class Event < ApplicationRecord
+        has_many :event_translations, foreign_key: 'spina_conferences_event_id'
+
+        translates :description, backend: :action_text
+      end
+    end
+  end
+end

--- a/lib/spina/admin/conferences.rb
+++ b/lib/spina/admin/conferences.rb
@@ -7,6 +7,7 @@ require 'rails-i18n'
 require 'stimulus-rails'
 require 'turbo-rails'
 require 'icalendar'
+require 'icalendar/tzinfo'
 
 # Spina content management system.
 # @see https://www.spinacms.com Spina website

--- a/lib/spina/admin/conferences/engine.rb
+++ b/lib/spina/admin/conferences/engine.rb
@@ -20,7 +20,10 @@ module Spina
           Spina::Part.register(Spina::Parts::Admin::Conferences::EmailAddress)
           Spina::Part.register(Spina::Parts::Admin::Conferences::Time)
           Spina::Part.register(Spina::Parts::Admin::Conferences::Url)
+        end
 
+        config.to_prepare do
+          require 'mobility/action_text'
         end
       end
     end

--- a/lib/spina/admin/conferences/engine.rb
+++ b/lib/spina/admin/conferences/engine.rb
@@ -21,11 +21,6 @@ module Spina
           Spina::Part.register(Spina::Parts::Admin::Conferences::Time)
           Spina::Part.register(Spina::Parts::Admin::Conferences::Url)
 
-          ActiveSupport::Deprecation
-            .new('2.0', 'Spina::Admin::Conferences')
-            .tap { |deprecator| deprecator.deprecate_methods(Conference, to_ics: :to_event) }
-            .tap { |deprecator| deprecator.deprecate_methods(Presentation, to_ics: :to_event) }
-            .tap { |deprecator| deprecator.deprecate_methods(Event, to_ics: :to_event) }
         end
       end
     end

--- a/spina-admin-conferences.gemspec
+++ b/spina-admin-conferences.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md']
 
   spec.add_dependency 'icalendar', '~> 2.5'
+  spec.add_dependency 'mobility-actiontext', '0.2.0'
   spec.add_dependency 'rails', '~> 6.0'
   spec.add_dependency 'rails-i18n', '~> 6.0'
   spec.add_dependency 'redis', '~> 4.2'

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_321_001_208) do
+ActiveRecord::Schema.define(version: 20_210_417_102_514) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -23,7 +23,8 @@ ActiveRecord::Schema.define(version: 20_210_321_001_208) do
     t.bigint 'record_id', null: false
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
-    t.index %w[record_type record_id name], name: 'index_action_text_rich_texts_uniqueness', unique: true
+    t.string 'locale'
+    t.index %w[record_type record_id name locale], name: 'index_action_text_rich_texts_uniqueness', unique: true
   end
 
   create_table 'active_storage_attachments', force: :cascade do |t|
@@ -52,6 +53,14 @@ ActiveRecord::Schema.define(version: 20_210_321_001_208) do
     t.bigint 'blob_id', null: false
     t.string 'variation_digest', null: false
     t.index %w[blob_id variation_digest], name: 'index_active_storage_variant_records_uniqueness', unique: true
+  end
+
+  create_table 'mobility_string_translations', force: :cascade do |t|
+    t.string 'record'
+  end
+
+  create_table 'mobility_text_translations', force: :cascade do |t|
+    t.string 'record'
   end
 
   create_table 'spina_accounts', id: :serial, force: :cascade do |t|
@@ -156,7 +165,6 @@ ActiveRecord::Schema.define(version: 20_210_321_001_208) do
 
   create_table 'spina_conferences_event_translations', force: :cascade do |t|
     t.string 'name'
-    t.text 'description'
     t.string 'location'
     t.string 'locale', null: false
     t.bigint 'spina_conferences_event_id', null: false
@@ -233,7 +241,6 @@ ActiveRecord::Schema.define(version: 20_210_321_001_208) do
 
   create_table 'spina_conferences_presentation_translations', force: :cascade do |t|
     t.string 'title'
-    t.text 'abstract'
     t.string 'locale', null: false
     t.bigint 'spina_conferences_presentation_id', null: false
     t.datetime 'created_at', precision: 6, null: false

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -2,3 +2,32 @@
 #   record: name_of_fixture (ClassOfFixture)
 #   name: content
 #   body: <p>In a <i>million</i> stars!</p>
+agm_description:
+  record: agm (Spina::Admin::Conferences::Event)
+  name: description
+  body: Annual general meeting.
+  locale: en-GB
+
+drinks_description:
+  record: drinks (Spina::Admin::Conferences::Event)
+  name: description
+  body: Pub trip.
+  locale: en-GB
+
+pub_crawl_description:
+  record: pub_crawl (Spina::Admin::Conferences::Event)
+  name: description
+  body: Pub trip 2.
+  locale: en-GB
+
+asymmetry_and_antisymmetry_abstract:
+  record: asymmetry_and_antisymmetry (Spina::Admin::Conferences::Presentation)
+  name: abstract
+  body: Lorem ipsum
+  locale: en-GB
+
+no_island_description:
+  record: no_island (Spina::Admin::Conferences::Presentation)
+  name: abstract
+  body: Dolor sit amen
+  locale: en-GB

--- a/test/fixtures/spina/admin/conferences/event/translations.yml
+++ b/test/fixtures/spina/admin/conferences/event/translations.yml
@@ -2,21 +2,18 @@
 
 agm:
   name: AGM
-  description: Annual general meeting.
   location: Broom cupboard 3
   locale: en-GB
   translated_model: agm
 
 drinks:
   name: Drinks
-  description: Pub trip.
   location: The Pickerel
   locale: en-GB
   translated_model: drinks
 
 pub_crawl:
   name: Pub crawl
-  description: Pub trip 2.
   location: Every pub
   locale: en-GB
   translated_model: pub_crawl

--- a/test/fixtures/spina/admin/conferences/presentation/translations.yml
+++ b/test/fixtures/spina/admin/conferences/presentation/translations.yml
@@ -6,12 +6,10 @@
 #
 asymmetry_and_antisymmetry:
   title: The Asymmetry and Antisymmetry of Syntax
-  abstract: Lorem ipsum
   locale: en-GB
   translated_model: asymmetry_and_antisymmetry
 
 no_island:
   title: No Island is an Island
-  abstract: Dolor sit amen
   locale: en-GB
   translated_model: no_island

--- a/test/models/spina/admin/conferences/conference_test.rb
+++ b/test/models/spina/admin/conferences/conference_test.rb
@@ -187,8 +187,6 @@ module Spina
         test 'returns an iCal event' do
           assert_instance_of Icalendar::Event, @conference.to_event
           assert_instance_of Icalendar::Event, @new_conference.to_event
-          assert_instance_of Icalendar::Event, @conference.to_ics
-          assert_instance_of Icalendar::Event, @new_conference.to_ics
         end
 
         test 'finish date saved correctly' do

--- a/test/models/spina/admin/conferences/conference_test.rb
+++ b/test/models/spina/admin/conferences/conference_test.rb
@@ -122,6 +122,16 @@ module Spina
           assert_not_empty @conference.presentation_types.last.errors
         end
 
+        test 'conferences return time zone periods' do
+          assert_kind_of Array, Conference.time_zone_periods
+          assert_kind_of Array, Conference.none.time_zone_periods
+        end
+
+        test 'conferences return an iCal calendar' do
+          assert_kind_of String, Conference.to_ics
+          assert_kind_of String, Conference.none.to_ics
+        end
+
         test 'conference returns a start date' do
           assert_equal @conference.dates.min, @conference.start_date
           assert_nil @new_conference.start_date

--- a/test/models/spina/admin/conferences/conference_test.rb
+++ b/test/models/spina/admin/conferences/conference_test.rb
@@ -199,6 +199,16 @@ module Spina
           assert_instance_of Icalendar::Event, @new_conference.to_event
         end
 
+        test 'returns a time zone period' do
+          assert_kind_of TZInfo::TimezonePeriod, @conference.time_zone_period
+          assert_nil @new_conference.time_zone_period
+        end
+
+        test 'returns an iCal calendar' do
+          assert_kind_of String, @conference.to_ics
+          assert_nil @new_conference.to_ics
+        end
+
         test 'finish date saved correctly' do
           assert_changes '@conference.finish_date', to: @conference.finish_date + 1.day do
             @conference.finish_date = (@conference.finish_date + 1.day).iso8601

--- a/test/models/spina/admin/conferences/event_test.rb
+++ b/test/models/spina/admin/conferences/event_test.rb
@@ -34,11 +34,11 @@ module Spina
         test 'translates description' do
           @event.description = 'foo'
           I18n.locale = :ja
-          assert_equal 'foo', @event.description
+          assert_equal 'foo', @event.description.to_plain_text
           @event.description = 'bar'
-          assert_equal 'bar', @event.description
+          assert_equal 'bar', @event.description.to_plain_text
           I18n.locale = I18n.default_locale
-          assert_equal 'foo', @event.description
+          assert_equal 'foo', @event.description.to_plain_text
         end
 
         test 'events have sorted scope' do

--- a/test/models/spina/admin/conferences/event_test.rb
+++ b/test/models/spina/admin/conferences/event_test.rb
@@ -124,6 +124,11 @@ module Spina
           assert_nil @new_event.date
         end
 
+        test 'returns a time zone period' do
+          assert_kind_of TZInfo::TimezonePeriod, @event.time_zone_period
+          assert_nil @new_event.time_zone_period
+        end
+
         test 'returns an iCal event' do
           assert_instance_of Icalendar::Event, @event.to_event
           assert_instance_of Icalendar::Event, @new_event.to_event

--- a/test/models/spina/admin/conferences/presentation_test.rb
+++ b/test/models/spina/admin/conferences/presentation_test.rb
@@ -170,6 +170,11 @@ module Spina
           assert_nil @new_presentation.start_time
         end
 
+        test 'returns finish datetime' do
+          assert_equal @presentation.start_datetime + @presentation.presentation_type.duration, @presentation.finish_datetime
+          assert_nil @new_presentation.finish_datetime
+        end
+
         test 'returns an iCal event' do
           assert_instance_of Icalendar::Event, @presentation.to_event
           assert_instance_of Icalendar::Event, @new_presentation.to_event

--- a/test/models/spina/admin/conferences/presentation_test.rb
+++ b/test/models/spina/admin/conferences/presentation_test.rb
@@ -24,13 +24,13 @@ module Spina
         end
 
         test 'translates abstract' do
-          @presentation.title = 'foo'
+          @presentation.abstract = 'foo'
           I18n.locale = :ja
-          assert_equal 'foo', @presentation.title
-          @presentation.title = 'bar'
-          assert_equal 'bar', @presentation.title
+          assert_equal 'foo', @presentation.abstract.to_plain_text
+          @presentation.abstract = 'bar'
+          assert_equal 'bar', @presentation.abstract.to_plain_text
           I18n.locale = I18n.default_locale
-          assert_equal 'foo', @presentation.title
+          assert_equal 'foo', @presentation.abstract.to_plain_text
         end
 
         test 'presentations have sorted scope' do

--- a/test/models/spina/admin/conferences/presentation_test.rb
+++ b/test/models/spina/admin/conferences/presentation_test.rb
@@ -175,6 +175,11 @@ module Spina
           assert_nil @new_presentation.finish_datetime
         end
 
+        test 'returns a time zone period' do
+          assert_kind_of TZInfo::TimezonePeriod, @presentation.time_zone_period
+          assert_nil @new_presentation.time_zone_period
+        end
+
         test 'returns an iCal event' do
           assert_instance_of Icalendar::Event, @presentation.to_event
           assert_instance_of Icalendar::Event, @new_presentation.to_event

--- a/test/models/spina/admin/conferences/presentation_test.rb
+++ b/test/models/spina/admin/conferences/presentation_test.rb
@@ -173,8 +173,6 @@ module Spina
         test 'returns an iCal event' do
           assert_instance_of Icalendar::Event, @presentation.to_event
           assert_instance_of Icalendar::Event, @new_presentation.to_event
-          assert_instance_of Icalendar::Event, @presentation.to_ics
-          assert_instance_of Icalendar::Event, @new_presentation.to_ics
         end
       end
     end


### PR DESCRIPTION
Calendars finally have timezone support. The implementation is somewhat different to what's shown in the `icalendar` gem's README—instead of trying to guess daylight savings rules (which are liable to change idiosyncratically without much notice), each change to and from daylight saving is represented separately in the iCalendar file. This of course results in a longer file, but since it's plaintext this probably doesn't matter very much unless thousands of years of events are being displayed (which seems unlikely for this gem). More work is now done in the model layer, with new `to_ics` methods, and there's more caching to make things speedy. This PR also moves translated texts handled by Mobility to an Action Text table so as to take advantage of Action Text's plain text conversion feature. This involves a new gem for a new Mobility backend. There's currently a known bug (https://github.com/sedubois/mobility-actiontext/issues/3) with Mobility that necessitates some unused tables—this will hopefully be fixed in the near future.